### PR TITLE
chore: sitemapがgithubに上がらないようにした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .next/
 .env
 .env.local
+public/


### PR DESCRIPTION
## 概要
sitemapがgithubに上がらないようにした

## 詳細（主に技術的変更点）
vercel上でsitemapが生成されるのを確認することができたので、あがらないようにした

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）


## 保留した項目・TODOリスト


## その他（レビューで見てもらいたい点、不安な点、参考URLなど）

